### PR TITLE
error: format not a string literal and no format arguments [-Werror=format-security]

### DIFF
--- a/src/common/singleapp/singleapp.cpp
+++ b/src/common/singleapp/singleapp.cpp
@@ -58,7 +58,7 @@ void SingleApp::receiveMessage()
         QLocalSocket *localSocket = localServer->nextPendingConnection();
         if (!localSocket->waitForReadyRead(timeout))
         {
-                qDebug(localSocket->errorString().toLatin1());
+                qDebug("%s", qPrintable(localSocket->errorString().toLatin1()));
                 return;
         }
         QByteArray byteArray = localSocket->readAll();
@@ -91,13 +91,13 @@ bool SingleApp::sendMessage(const QString &message)
         localSocket.connectToServer(uniqueKey, QIODevice::WriteOnly);
         if (!localSocket.waitForConnected(timeout))
         {
-                qDebug(localSocket.errorString().toLatin1());
+                qDebug("%s",qPrintable(localSocket.errorString().toLatin1()));
                 return false;
         }
         localSocket.write(message.toUtf8());
         if (!localSocket.waitForBytesWritten(timeout))
         {
-                qDebug(localSocket.errorString().toLatin1());
+                qDebug("%s",qPrintable(localSocket.errorString().toLatin1()));
                 return false;
         }
         localSocket.disconnectFromServer();


### PR DESCRIPTION
error: format not a string literal and no format arguments [-Werror=format-security]
cc1plus: some warnings being treated as errors
